### PR TITLE
Update CouchDB

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Alejandro (Sasha) Vicente Grabovetsky'
 # The short X.Y version
 version = '0.2'
 # The full version, including alpha/beta/rc tags
-release = '0.2.1'
+release = '0.2.2'
 
 
 # -- General configuration ---------------------------------------------------
@@ -43,7 +43,8 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'm2r',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Welcome to Nephos's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   readme
 
 
 Indices and tables

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../README.md

--- a/nephos/fabric/peer.py
+++ b/nephos/fabric/peer.py
@@ -17,7 +17,7 @@ from time import sleep
 
 from nephos.fabric.settings import get_namespace
 from nephos.fabric.utils import get_pod
-from nephos.helpers.helm import helm_install, helm_upgrade
+from nephos.helpers.helm import HelmPreserve, helm_install, helm_upgrade
 from nephos.helpers.misc import execute
 
 
@@ -93,15 +93,13 @@ def setup_peer(opts, upgrade=False, verbose=False):
                 verbose=verbose,
             )
         else:
-            # We will not upgrade the CouchDB here, only explicitly in a separate script.
-            pass
-            # preserve = (HelmPreserve('cdb-{}-hlf-couchdb'.format(release), 'COUCHDB_USERNAME', 'couchdbUsername'),
-            #             HelmPreserve('cdb-{}-hlf-couchdb'.format(release), 'COUCHDB_PASSWORD', 'couchdbPassword'))
-            # helm_upgrade(opts['core']['chart_repo'], 'hlf-couchdb', 'cdb-{}'.format(release), peer_namespace,
-            #              config_yaml='{dir}/hlf-couchdb/cdb-{name}.yaml'.format(dir=opts['core']['dir_values'],
-            #                                                                     name=release),
-            #              preserve=preserve,
-            #              verbose=verbose)
+            preserve = (HelmPreserve('cdb-{}-hlf-couchdb'.format(release), 'COUCHDB_USERNAME', 'couchdbUsername'),
+                        HelmPreserve('cdb-{}-hlf-couchdb'.format(release), 'COUCHDB_PASSWORD', 'couchdbPassword'))
+            helm_upgrade(opts['core']['chart_repo'], 'hlf-couchdb', 'cdb-{}'.format(release), peer_namespace,
+                         config_yaml='{dir}/hlf-couchdb/cdb-{name}.yaml'.format(dir=opts['core']['dir_values'],
+                                                                                name=release),
+                         preserve=preserve,
+                         verbose=verbose)
 
         # Deploy the HL-Peer charts
         if not upgrade:

--- a/nephos/helpers/helm.py
+++ b/nephos/helpers/helm.py
@@ -198,8 +198,8 @@ def helm_upgrade(
         release (str): Release name on K8S.
         namespace (str): Namespace where to deploy Helm Chart.
         config_yaml (str): Values file to ovverride defaults.
-        env_vars (list): Environmental variables we wish to store in Helm.
-        preserve (list): Set of secrets we wish to get data from to assign to the Helm Chart.
+        env_vars (tuple): Environmental variables we wish to store in Helm.
+        preserve (tuple): Set of secrets we wish to get data from to assign to the Helm Chart.
         verbose (bool): Verbosity. False by default.
         pod_num (int): Number of pods we wish to have.
     """

--- a/nephos/upgrade_v11x.py
+++ b/nephos/upgrade_v11x.py
@@ -20,15 +20,15 @@ import os
 import click
 from kubernetes.client.rest import ApiException
 
-from nephos.fabric.settings import get_namespace, load_config
-from nephos.fabric.utils import get_pod
+from nephos.fabric.crypto import CryptoInfo
 from nephos.fabric.ord import check_ord
 from nephos.fabric.peer import check_peer
+from nephos.fabric.settings import get_namespace, load_config
+from nephos.fabric.utils import get_pod
 from nephos.helpers.helm import helm_upgrade
-from nephos.helpers.k8s import ns_create, secret_read, secret_create
+from nephos.helpers.k8s import secret_read, secret_create
 
 PWD = os.getcwd()
-CryptoInfo = namedtuple("CryptoInfo", ("secret_type", "subfolder", "key", "required"))
 
 NODE_MAPPER = {"orderer": "hlf-ord", "peer": "hlf-peer"}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,10 @@ idna==2.8
 imagesize==1.1.0
 Jinja2==2.10
 kubernetes==8.0.0
+m2r==0.2.1
 MarkupSafe==1.1.0
+mistune==0.8.4
 more-itertools==4.3.0
-nephos==0.1.7
 oauthlib==2.1.0
 packaging==19.0
 pkginfo==1.4.2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ URL = "https://github.com/aidtechnology/nephos"
 EMAIL = "sasha@aid.technology"
 AUTHOR = "Alejandro (Sasha) Vicente Grabovetsky"
 REQUIRES_PYTHON = ">=3.7.0"
-VERSION = "0.2.1"
+VERSION = "0.2.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = ["blessings", "click", "kubernetes", "pygments"]

--- a/tests/fabric/test_peer.py
+++ b/tests/fabric/test_peer.py
@@ -3,6 +3,7 @@ from unittest import mock
 from unittest.mock import call
 
 from nephos.fabric.peer import check_ord_tls, check_peer, setup_peer, setup_channel
+from nephos.helpers.helm import HelmPreserve
 
 
 class TestCheckOrdTls:
@@ -134,14 +135,26 @@ class TestSetupPeer:
         OPTS["peers"]["names"] = ["peer0"]
         setup_peer(OPTS, upgrade=True)
         mock_helm_install.assert_not_called()
-        mock_helm_upgrade.assert_called_once_with(
-            "a-repo",
-            "hlf-peer",
-            "peer0",
-            "peer-namespace",
-            config_yaml="./a_dir/hlf-peer/peer0.yaml",
-            verbose=False,
-        )
+        mock_helm_upgrade.assert_has_calls([
+            call(
+                "a-repo",
+                "hlf-couchdb",
+                "cdb-peer0",
+                "peer-namespace",
+                config_yaml="./a_dir/hlf-couchdb/cdb-peer0.yaml",
+                preserve=(HelmPreserve('cdb-peer0-hlf-couchdb', 'COUCHDB_USERNAME', 'couchdbUsername'),
+                          HelmPreserve('cdb-peer0-hlf-couchdb', 'COUCHDB_PASSWORD', 'couchdbPassword')),
+                verbose=False
+            ),
+            call(
+                "a-repo",
+                "hlf-peer",
+                "peer0",
+                "peer-namespace",
+                config_yaml="./a_dir/hlf-peer/peer0.yaml",
+                verbose=False
+            )
+        ])
         mock_check_peer.assert_called_once_with(
             "peer-namespace", "peer0", verbose=False
         )


### PR DESCRIPTION
We enable updating CouchDB (at your own risk) when upgrading the peers.

We improve the Nephos documentation on https://nephos.readthedocs.io by including the README.md